### PR TITLE
Infra - docker-compose.yml adaptado para o MacOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,8 @@ docker compose exec app php artisan app:populate-teams-command
 ```bash
 docker compose exec app php artisan app:populate-players-command
 ```
+
+## Como executar os testes
+```bash
+docker compose exec app php artisan test
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@ version: "3"
 services:
   app:
     build: .
-    volumes:
-      - ./:/var/www/html
-      - ./.env.example:/var/www/html/.env
     environment:
       - PHP_OPCACHE_VALIDATE_TIMESTAMPS=0
       - PHP_OPCACHE_MAX_ACCELERATED_FILES=10000


### PR DESCRIPTION
Devido a sobrescrita de volume no docker-compose perdíamos a ./vendor após instalar as dependências via composer;